### PR TITLE
Version Bump to Reflect WordPress 5.2.2 Testing

### DIFF
--- a/genesis-responsive-slider.php
+++ b/genesis-responsive-slider.php
@@ -3,7 +3,7 @@
  * Plugin Name: Genesis Responsive Slider
  * Plugin URI: https://www.studiopress.com
  * Description: A responsive featured slider for the Genesis Framework.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: StudioPress
  * Author URI: https://www.studiopress.com
  * License: GNU General Public License v2.0 (or later)
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 define( 'GENESIS_RESPONSIVE_SLIDER_SETTINGS_FIELD', 'genesis_responsive_slider_settings' );
-define( 'GENESIS_RESPONSIVE_SLIDER_VERSION', '1.0.0' );
+define( 'GENESIS_RESPONSIVE_SLIDER_VERSION', '1.0.1' );
 define( 'GENESIS_RESPONSIVE_SLIDER_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
 define( 'GENESIS_RESPONSIVE_SLIDER_PLUGIN_URL', plugins_url( '', __FILE__ ) );
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "description": "A responsive featured slider for the Genesis Framework.",
     "author": "StudioPress",
     "authoruri": "http://www.studiopress.com/",
-    "version": "0.9.6",
+    "version": "1.0.1",
     "license": "GPL-2.0+",
     "licenseuri": "http://www.gnu.org/licenses/gpl-2.0.html",
     "textdomain": "genesis-simple-share"

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: marksabbath, nathanrice, studiopress, wpmuguru
 Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=5553118
 Tags: slider, slideshow, responsive, genesis, genesiswp, studiopress
 Requires at least: 3.2
-Tested up to: 5.1
-Stable tag: 1.0.0
+Tested up to: 5.2.2
+Stable tag: 1.0.1
 
 This plugin allows you to create a simple responsive slider that displays the featured image, along with the title and excerpt from each post.
 
@@ -65,6 +65,9 @@ function my_child_theme_responsive_slider_defaults( $defaults ) {
 `
 
 == Changelog ==
+
+= 1.0.1 =
+* Tested on WordPress 5.2.2
 
 = 1.0.0 =
 * Major restructuring


### PR DESCRIPTION
**Summary of change:**
Version Bump to Reflect Testing with WordPress 5.2.2. 

**Please see https://github.com/studiopress/genesis-responsive-slider/issues/12 before merging.**

**This PR has been:**
- [x] Linted for syntax errors
- [x] Tested against the WordPress coding standards
- [x] Tested with the bundled test suite(s)
